### PR TITLE
APIS-2525-migrate-ruby-3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Gemfile.lock
 .bundle
 examples/staging.rb
 examples/production.rb
+.tool-versions
+vendor/

--- a/aweber.gemspec
+++ b/aweber.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   
   s.add_development_dependency "fakeweb"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 2.11.0"
+  s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "yard",  "~> 0.6.0"
 end
 

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -59,7 +59,7 @@ describe AWeber::Resource do
   
   it "should declare writable attributes" do
     resource = FakeResource.new(@aweber)
-    resource.writable_attrs.include?(:name).should be_true
+    resource.writable_attrs.include?(:name).should be_truthy
   end
   
   it "should send a JSON respresentation of the object on save" do

--- a/spec/resources/account_spec.rb
+++ b/spec/resources/account_spec.rb
@@ -20,7 +20,7 @@ describe AWeber::Resources::Account do
 
   it "should find subscribers" do
     subscribers = account.find_subscribers(:email => 'joe@example.com')
-    subscribers.should_not be_false
+    subscribers.should_not be_falsey
     subscribers.should be_an AWeber::Collection
     subscribers.size.should == 1
     subscribers.first[1].self_link.should == 'https://api.aweber.com/1.0/accounts/1/lists/303449/subscribers/1'

--- a/spec/resources/account_spec.rb
+++ b/spec/resources/account_spec.rb
@@ -5,8 +5,10 @@ describe AWeber::Resources::Account do
   let(:account) { aweber.account }
   subject { account }
   
-  its(:path) { should == "/accounts/1" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1")
+  end
+
   it { should respond_to :id }
   it { should respond_to :http_etag }
   it { should respond_to :self_link }
@@ -29,7 +31,10 @@ describe AWeber::Resources::Account do
     subject { webforms }
 
     it { should be_an Array }
-    its(:size) { should == 181 }
+
+    it 'should be the correct size' do
+      expect(subject.size).to eq(181)
+    end
     
     it "should be a list of Web Forms" do
       webforms[0].should be_an AWeber::Resources::WebForm
@@ -47,7 +52,10 @@ describe AWeber::Resources::Account do
     subject { split_tests }
 
     it { should be_an Array }
-    its(:size) { should == 10 }
+
+    it 'should be the correct size' do
+      expect(subject.size).to eq(10)
+    end
     
     it "should be a list of Web Forms" do
       split_tests[0].should be_an AWeber::Resources::WebFormSplitTest

--- a/spec/resources/campaign_spec.rb
+++ b/spec/resources/campaign_spec.rb
@@ -4,7 +4,9 @@ describe "AWeber::Resources::Campaign" do
   include BaseObjects
   subject { aweber.account.lists[1].campaigns[50000047] }
   
-  its(:path) { should == "/accounts/1/lists/1/campaigns/50000047" }
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/campaigns/50000047")
+  end
   
   it { should respond_to :campaign_type }
   it { should respond_to :click_tracking_enabled }

--- a/spec/resources/click_spec.rb
+++ b/spec/resources/click_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::Click do
   include BaseObjects
   subject { aweber.account.lists[1].campaigns[50000047].links[136340].clicks[129530] }
   
-  its(:path) { should == "/accounts/1/lists/1/campaigns/50000047/links/136340/clicks/129530" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/campaigns/50000047/links/136340/clicks/129530")
+  end
+
   it { should respond_to :event_time }
   it { should respond_to :http_etag }
   it { should respond_to :id }

--- a/spec/resources/custom_field_spec.rb
+++ b/spec/resources/custom_field_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::CustomField do
   include BaseObjects
   subject { aweber.account.lists[1].custom_fields[1] }
   
-  its(:path) { should == "/accounts/1/lists/1/custom_fields/1" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/custom_fields/1")
+  end
+
   it { should respond_to :name }
   it { should respond_to :is_subscriber_updateable }
   it { should respond_to :is_subscriber_updateable? }

--- a/spec/resources/integration_spec.rb
+++ b/spec/resources/integration_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::Integration do
   include BaseObjects
   subject { aweber.account.integrations[8076] }
   
-  its(:path) { should == "/accounts/1/integrations/8076" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/integrations/8076")
+  end
+
   it { should respond_to :http_etag }
   it { should respond_to :id }
   it { should respond_to :login }

--- a/spec/resources/link_spec.rb
+++ b/spec/resources/link_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::Link do
   include BaseObjects
   subject { aweber.account.lists[1].campaigns[50000047].links[136340] }
   
-  its(:path) { should == "/accounts/1/lists/1/campaigns/50000047/links/136340" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/campaigns/50000047/links/136340")
+  end
+
   it { should respond_to :clicks_collection_link }
   it { should respond_to :http_etag }
   it { should respond_to :id }

--- a/spec/resources/list_spec.rb
+++ b/spec/resources/list_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::List do
   include BaseObjects
   subject { aweber.account.lists[1] }
   
-  its(:path) { should == "/accounts/1/lists/1" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1")
+  end
+
   it { should respond_to :campaigns_collection_link }
   it { should respond_to :http_etag }
   it { should respond_to :id }

--- a/spec/resources/message_spec.rb
+++ b/spec/resources/message_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::Message do
   include BaseObjects
   subject { aweber.account.lists[1].campaigns[50000047].messages[11839] }
   
-  its(:path) { should == "/accounts/1/lists/1/campaigns/50000047/messages/11839" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/campaigns/50000047/messages/11839")
+  end
+
   it { should respond_to :event_time }
   it { should respond_to :http_etag }
   it { should respond_to :id }

--- a/spec/resources/open_spec.rb
+++ b/spec/resources/open_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::Open do
   include BaseObjects
   subject { aweber.account.lists[1].campaigns[50000047].messages[11839].opens[11721] }
   
-  its(:path) { should == "/accounts/1/lists/1/campaigns/50000047/messages/11839/opens/11721" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/campaigns/50000047/messages/11839/opens/11721")
+  end
+
   it { should respond_to :event_time }
   it { should respond_to :http_etag }
   it { should respond_to :id }

--- a/spec/resources/stat_spec.rb
+++ b/spec/resources/stat_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::Link do
   include BaseObjects
   subject { aweber.account.lists[1].campaigns[50000047].stats['total_clicks'] }
   
-  its(:path) { should == "/accounts/1/lists/1/campaigns/50000047/stats/total_clicks" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/campaigns/50000047/stats/total_clicks")
+  end
+
   it { should respond_to :description }
   it { should respond_to :http_etag }
   it { should respond_to :id }

--- a/spec/resources/subscriber_spec.rb
+++ b/spec/resources/subscriber_spec.rb
@@ -22,16 +22,20 @@ describe AWeber::Resources::Subscriber do
   it { should respond_to :subscription_url }
   it { should respond_to :unsubscribed_at }
   it { should respond_to :verified_at }
+ 
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/subscribers/50723026")
+  end
 
-  its(:path)           { should == "/accounts/1/lists/1/subscribers/50723026" }
-
-  its(:writable_attrs) { should include :name }
-  its(:writable_attrs) { should include :misc_notes }
-  its(:writable_attrs) { should include :email }
-  its(:writable_attrs) { should include :status }
-  its(:writable_attrs) { should include :custom_fields }
-  its(:writable_attrs) { should include :ad_tracking }
-  its(:writable_attrs) { should include :last_followup_message_number_sent }
+  it 'should have the correct writable attributes' do
+    expect(subject.writable_attrs).to include :name
+    expect(subject.writable_attrs).to include :misc_notes
+    expect(subject.writable_attrs).to include :email
+    expect(subject.writable_attrs).to include :status
+    expect(subject.writable_attrs).to include :custom_fields
+    expect(subject.writable_attrs).to include :ad_tracking
+    expect(subject.writable_attrs).to include :last_followup_message_number_sent
+  end
 
   it "should move lists" do
     list = "http://api.aweber.com/1.0/accounts/1/lists/987654"

--- a/spec/resources/tracked_event_spec.rb
+++ b/spec/resources/tracked_event_spec.rb
@@ -4,8 +4,10 @@ describe AWeber::Resources::TrackedEvent do
   include BaseObjects
   subject { aweber.account.lists[1].campaigns[50000047].messages[11839].tracked_events[11839] }
   
-  its(:path) { should == "/accounts/1/lists/1/campaigns/50000047/messages/11839/tracked_events/11839" }
-  
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/campaigns/50000047/messages/11839/tracked_events/11839")
+  end
+
   it { should respond_to :event_time }
   it { should respond_to :http_etag }
   it { should respond_to :id }

--- a/spec/resources/web_form_spec.rb
+++ b/spec/resources/web_form_spec.rb
@@ -3,8 +3,10 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe AWeber::Resources::WebForm do
   include BaseObjects
   subject { aweber.account.lists[1].web_forms[1911952229] }
-  
-  its(:path) { should == "/accounts/1/lists/1/web_forms/1911952229" }
+
+  it 'should be the correct path' do 
+    expect(subject.path).to eq("/accounts/1/lists/1/web_forms/1911952229")
+  end
   
   it { should respond_to :conversion_percentage }
   it { should respond_to :http_etag }

--- a/spec/resources/web_form_split_test_component_spec.rb
+++ b/spec/resources/web_form_split_test_component_spec.rb
@@ -3,8 +3,10 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe AWeber::Resources::WebFormSplitTestComponent do
   include BaseObjects
   subject { aweber.account.lists[1].web_form_split_tests[1242668124].components["612763163-513600765"] }
-  
-  its(:path) { should == "/accounts/1/lists/1/web_form_split_tests/1242668124/components/612763163-513600765" }
+
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/web_form_split_tests/1242668124/components/612763163-513600765")
+  end
   
   it { should respond_to :conversion_percentage }
   it { should respond_to :http_etag }

--- a/spec/resources/web_form_split_test_spec.rb
+++ b/spec/resources/web_form_split_test_spec.rb
@@ -4,7 +4,9 @@ describe AWeber::Resources::WebFormSplitTest do
   include BaseObjects
   subject { aweber.account.lists[1].web_form_split_tests[1242668124] }
   
-  its(:path) { should == "/accounts/1/lists/1/web_form_split_tests/1242668124" }
+  it 'should be the correct path' do
+    expect(subject.path).to eq("/accounts/1/lists/1/web_form_split_tests/1242668124")
+  end
   
   it { should respond_to :components_collection_link }
   it { should respond_to :http_etag }


### PR DESCRIPTION
- update rspec to latest version and remove its which is no longer supported
- updated gitignore
- address a few more spec expectations
