### PR TITLE
APIS 2525 migrate ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 1.7.0 - 2023-10-20
+- Updated rspec to the latest version for compatibility with ruby 3.2.2

--- a/README.textile
+++ b/README.textile
@@ -1,6 +1,6 @@
-h1. This client library has been deprecated.
+h1. This is a fork of a deprecated library which is no longer supported.
 
-h3. This library will no longer be supported and does not support OAuth2. 
+h3. This library does not support OAuth2. 
 
 h1. AWeber API Gem "!https://secure.travis-ci.org/aweber/AWeber-API-Ruby-Library.png?branch=master!":http://travis-ci.org/aweber/AWeber-API-Ruby-Library
 

--- a/aweber.gemspec
+++ b/aweber.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name         = "aweber"
-  s.version      = "1.6.1"
+  s.version      = "1.7.0"
   s.platform     = Gem::Platform::RUBY
   s.summary      = "Ruby interface to AWeber's API"
   s.description  = "Ruby interface to AWeber's API"


### PR DESCRIPTION
- update rspec to latest version and remove its which is no longer supported
- updated gitignore
- address a few more spec expectations
- add changelog and bump up version based on rspec update
